### PR TITLE
three.js - Add missing WebGLRenderer methods

### DIFF
--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5548,7 +5548,7 @@ export class WebGLRenderer implements Renderer {
      * Sets the viewport to render from (x, y) to (x + width, y + height).
      */
     setViewport(x?: number, y?: number, width?: number, height?: number): void;
-	
+
     /**
      * Sets the scissor area from (x, y) to (x + width, y + height).
      */

--- a/types/three/three-core.d.ts
+++ b/types/three/three-core.d.ts
@@ -5535,16 +5535,20 @@ export class WebGLRenderer implements Renderer {
 
     getSize(): { width: number; height: number; };
 
+	getDrawingBufferSize(): { width: number; height: number; };
+	setDrawingBufferSize(width: number, height: number, pixelRatio: number): void;
+	
     /**
      * Resizes the output canvas to (width, height), and also sets the viewport to fit that size, starting in (0, 0).
      */
     setSize(width: number, height: number, updateStyle?: boolean): void;
 
+	getCurrentViewport(): Vector4;
     /**
      * Sets the viewport to render from (x, y) to (x + width, y + height).
      */
     setViewport(x?: number, y?: number, width?: number, height?: number): void;
-
+	
     /**
      * Sets the scissor area from (x, y) to (x + width, y + height).
      */


### PR DESCRIPTION
Add missing WebGLRenderer methods (getDrawingBufferSize, setDrawingBufferSize, getCurrentViewport)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://threejs.org/docs/#api/renderers/WebGLRenderer
